### PR TITLE
Stop exporting `lib/config.ts` by default

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,4 +1,3 @@
-export * from "./types"
-export * from "./config"
+export * from "./types";
 export * from "./components";
-export { default as BaseWrapper } from "./base-wrapper"
+export { default as BaseWrapper } from "./base-wrapper";


### PR DESCRIPTION
So the client hasn't to install hardhat.